### PR TITLE
Fix for "Error: None of the directories given contain .fastq(.gz) files."

### DIFF
--- a/lib/fastqingress.nf
+++ b/lib/fastqingress.nf
@@ -331,10 +331,10 @@ def handle_non_barcoded_dirs(non_barcoded_dirs, approx_size)
 def fastq_ingress(input, output_folder, sample, sample_sheet, sanitize, min_barcode, max_barcode, approx_size)
 {   
     println("Checking fastq input.")
-    input = file(input);
+    input_file = file(input);
 
     // Handle file input
-    if (input.isFile()) {
+    if (input_file.isFile()) {
         // Assume sample is a string at this point
         println('Single file input detected.')
         if (sample_sheet) {
@@ -344,7 +344,7 @@ def fastq_ingress(input, output_folder, sample, sample_sheet, sanitize, min_barc
     }
 
     // Handle directory input
-    if (input.isDirectory()) {
+    if (input_file.isDirectory()) {
         // EPI2ME harness 
         if (sanitize) {
             staging = file(output_folder).resolve("staging")


### PR DESCRIPTION
As reported by one of our customers when testing this pipeline on AWS Batch via Nextflow Tower.

![image](https://user-images.githubusercontent.com/23529759/175045101-f38b28ac-226f-4d04-aaae-b9351d0a71de.png)

The input variable is being overwritten [here](https://github.com/epi2me-labs/wf-clone-validation/blob/0a321c100f3aa17208c23259fc28d2928adadfb0/lib/fastqingress.nf#L334) by a file object, and this file object is then passed to the [get_subdirectories](https://github.com/epi2me-labs/wf-clone-validation/blob/0a321c100f3aa17208c23259fc28d2928adadfb0/lib/fastqingress.nf#L355) function which is expecting a string [here](https://github.com/epi2me-labs/wf-clone-validation/blob/0a321c100f3aa17208c23259fc28d2928adadfb0/lib/fastqingress.nf#L115).

The fix was to re-assign the `input` variable as done in this PR.

For testing purposes, I used a random dataset containing FastQ files but the core parameter changes to the pipeline can be seen in the log output above.